### PR TITLE
export bitcore

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,8 @@ export * from './lib/bitdbnetwork';
 export * from './lib/localvalidator';
 export * from './lib/bitboxnetwork';
 export * from './lib/transactionhelpers';
+import * as bitcore from "bitcore-lib-cash";
+export {bitcore};
 
 import BigNumber from 'bignumber.js';
 


### PR DESCRIPTION
Allows for projects using slpjs to use same bitcore to avoid bitcore's double import error. 