### PR TITLE
"Fix" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SLPJS
 
-SLPJS is a JavaScript Library for validating and building [Simple Ledger Protocol (SLP)](https://github.com/simpleledger/slp-specification/blob/master/slp-token-type-1.md) token transactions.   GENESIS, MINT, and SEND token functions are supported.  See [change log](#change-log) for updates.
+SLPJS is a JavaScript Library for validating and building [Simple Ledger Protocol (SLP)](https://github.com/simpleledger/slp-specifications/blob/master/slp-token-type-1.md) token transactions.   GENESIS, MINT, and SEND token functions are supported.  See [change log](#change-log) for updates.
 
 [![NPM](https://nodei.co/npm/slpjs.png)](https://nodei.co/npm/slpjs/)
 


### PR DESCRIPTION
The old link pointed to slp-specification which is no longer the name of the repo, it redirects but it's nicer to have it go directly.