### PR TITLE
Update bchaddr dependency version and expose slp-regtest function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+  - 10
+  - 12
+  - 14.15
+sudo: false
+script:
+  - npm test
+after_success:
+  - npm run coverage

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -38,6 +38,10 @@ export class Utils {
         return Bchaddr.toSlpAddress(address);
     }
 
+    public static toSlpRegtestAddress(address: string) {
+        return Bchaddr.toSlpRegtestAddress(address);
+    }
+
     public static toRegtestAddress(address: string) {
         return Bchaddr.toRegtestAddress(address);
     }

--- a/lib/vendors.d.ts
+++ b/lib/vendors.d.ts
@@ -6,6 +6,7 @@ declare module "bchaddrjs-slp" {
     export function toLegacyAddress(address: string): string;
     export function isSlpAddress(address: string): boolean;
     export function toSlpAddress(address: string): string;
+    export function toSlpRegtestAddress(address: string): string;
     export function toRegtestAddress(address: string): string;
     export function decodeAddress(address: string): AddressDetails;
     export function encodeAsSlpaddr(decoded: AddressDetails): string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -874,9 +874,9 @@
       "dev": true
     },
     "bchaddrjs-slp": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/bchaddrjs-slp/-/bchaddrjs-slp-0.2.8.tgz",
-      "integrity": "sha512-Is4NQG0xhrmW8ml40n8IjQzYlg1gMqst2RkF20SWjuhiSA8VDx1F53krthFqZFp5hpB+Ig/NPx6NX4VEH9W32Q==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/bchaddrjs-slp/-/bchaddrjs-slp-0.2.12.tgz",
+      "integrity": "sha512-yRtNSo/oPqdl3R3LV9H6fvuksdA/FGvn/8A8IH2dkYLiVe5lOtBjiGV4qFMRUHCtwaXWumbBcUwgvdkXxj3cfg==",
       "requires": {
         "bs58check": "^2.1.2",
         "cashaddrjs-slp": "^0.2.12"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dist/"
   ],
   "scripts": {
-    "test": "npx tsc && nyc mocha",
+    "test": "mocha",
+    "coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
     "build": "npx tsc && mkdirp dist && browserify index.js --standalone slpjs > dist/slpjs.js && uglifyjs dist/slpjs.js > dist/slpjs.min.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@types/socket.io-client": "^1.4.33",
     "@types/wif": "^2.0.1",
     "axios": "^0.21.1",
-    "bchaddrjs-slp": "0.2.8",
+    "bchaddrjs-slp": "0.2.12",
     "bignumber.js": "9.0.0",
     "crypto-js": "^4.0.0",
     "grpc-bchrpc": "^0.0.10",

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -148,6 +148,10 @@ describe("Utils", () => {
             const addr = Utils.toCashAddress("simpleledger:qr5agtachyxvrwxu76vzszan5pnvuzy8duhv4lxrsk");
             assert.equal(addr, "bitcoincash:qr5agtachyxvrwxu76vzszan5pnvuzy8dumh7ynrwg");
         });
+        it("toSlpRegtestAddress()", () => {
+            const addr = Utils.toSlpRegtestAddress("simpleledger:qph5kuz78czq00e3t85ugpgd7xmer5kr7ccj3fcpsg");
+            assert.equal(addr, "slpreg:qph5kuz78czq00e3t85ugpgd7xmer5kr7ch8j98fn9");
+        });
         it("isCashAddress()", () => {
             const addr = Utils.isCashAddress("bitcoincash:qr5agtachyxvrwxu76vzszan5pnvuzy8dumh7ynrwg");
             assert.equal(addr, true);


### PR DESCRIPTION
Regtest functions in bchaddr-js not accessible with the current dependency version 0.2.8, updates version to 0.2.12 and exports the functions so they are visible.

Required for simpleledger/SLPDB#82
